### PR TITLE
Fix: de-duplicate azimuths in `_sweep_sampler` for a strict interpolator axis

### DIFF
--- a/pyart/retrieve/advect_interpolate.py
+++ b/pyart/retrieve/advect_interpolate.py
@@ -15,6 +15,7 @@ gate geometry, so the returned object is an ordinary
 """
 
 import copy
+import warnings
 
 import numpy as np
 from netCDF4 import num2date
@@ -154,14 +155,32 @@ def _displacement_interpolators(disp_y, disp_x, echo_mask, z, y, x):
 
 
 def _sweep_sampler(radar, sweep, field):
-    """Return (azimuth_sorted_deg, range_m, values, ) for one sweep, az-sorted."""
+    """Return (azimuth_sorted_deg, range_m, values, ) for one sweep, az-sorted.
+
+    Azimuths are sorted and de-duplicated: a strictly ascending axis is
+    required by the RegularGridInterpolator in :py:func:`_sample_native`, but
+    real volumes routinely repeat an azimuth (e.g. an extra wrap-past-start ray
+    on the top sweep). Rays sharing an azimuth are collapsed to their mean.
+    """
     start, end = radar.get_start_end(sweep)
     az = radar.azimuth["data"][start : end + 1]
     data = np.ma.filled(
         radar.fields[field]["data"][start : end + 1].astype("float64"), np.nan
     )
     order = np.argsort(az)
-    return az[order], radar.range["data"], data[order]
+    az_sorted, data_sorted = az[order], data[order]
+
+    az_unique, inv = np.unique(az_sorted, return_inverse=True)
+    if az_unique.size != az_sorted.size:
+        # collapse duplicate-azimuth rays to their nanmean so the axis is strict
+        collapsed = np.full((az_unique.size, data_sorted.shape[1]), np.nan)
+        for j in range(az_unique.size):
+            rows = data_sorted[inv == j]
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", category=RuntimeWarning)
+                collapsed[j] = np.nanmean(rows, axis=0)
+        az_sorted, data_sorted = az_unique, collapsed
+    return az_sorted, radar.range["data"], data_sorted
 
 
 def _sample_native(az_query, range_query, sampler):


### PR DESCRIPTION
## Summary
`advection_interpolate` raises `ValueError: The points in dimension 0 must be
strictly ascending or descending` on real radar volumes whose sweeps contain a
repeated azimuth. This fixes `_sweep_sampler` to de-duplicate azimuths so the
`RegularGridInterpolator` in `_sample_native` always receives a strictly
monotonic axis.

## Motivation
`_sample_native` builds a `RegularGridInterpolator` over the sweep azimuth axis
(tiled by ±360° to wrap the 0/360 discontinuity). That interpolator requires a
**strictly** ascending axis. `_sweep_sampler` sorted the azimuths but did not
de-duplicate them, so any sweep with a repeated azimuth produced a non-strict
axis and the call failed.

Repeated azimuths are common in operational data — the top (highest-elevation)
sweep of a volume frequently has one extra ray where the antenna wraps just past
its start azimuth. Without this fix the function fails on a large fraction of
real volumes.

## Reproduction
Observed on ARM BNF CSAPR2 (`bnfcsapr2cfrS3.a1`), QLCS case 2025-04-06 05:30 UTC:
the 05:30 volume's sweep 14 has 361 rays but only 360 unique azimuths (one
duplicate), which triggered the error on the first `advection_interpolate` call.

## Fix
In `_sweep_sampler`, after sorting, detect duplicate azimuths with
`np.unique(..., return_inverse=True)` and collapse rays sharing an azimuth to
their `nanmean`. When there are no duplicates the sort path is unchanged (zero
behavioural difference), so this is a safe, minimal change confined to one
helper.

## Testing
With the fix, `advection_interpolate` runs cleanly on the QLCS sequence and
produces spatially coherent interpolated volumes (validated by generating 4
evenly-spaced sub-volumes between each pair of observed 10-min volumes and
inspecting the native-geometry 2.5° PPI sequence — smooth advection, no
discontinuity at observed→interpolated transitions).

## Suggested follow-up
Add a regression unit test that runs `advection_interpolate` (or calls
`_sweep_sampler` directly) on a synthetic volume containing a duplicate-azimuth
sweep, asserting the returned azimuth axis is strictly increasing.