### PR TITLE
Feature: `advection_interpolate` accepts a list of fields

### DIFF
--- a/pyart/retrieve/advect_interpolate.py
+++ b/pyart/retrieve/advect_interpolate.py
@@ -209,6 +209,7 @@ def advection_interpolate(
     grid_limits=((1000.0, 8000.0), (-120000.0, 120000.0), (-120000.0, 120000.0)),
     echo_threshold=5.0,
     interp_field_name=None,
+    flow_field=None,
     gridding_kwargs=None,
     **flow_kwargs,
 ):
@@ -221,21 +222,33 @@ def advection_interpolate(
     time along that field and blending. The output is on the native geometry of
     ``radar1``.
 
+    The motion field is always estimated from a single field (``flow_field``),
+    since the echo motion is a property of the scene rather than of any one
+    moment. That single displacement field is then applied to interpolate every
+    field in ``field``, so multiple moments (e.g. reflectivity, velocity,
+    differential reflectivity) can be reconstructed in one call without
+    re-estimating the flow. The gridding and per-sweep advection geometry are
+    computed once and reused across all interpolated fields.
+
     Requires scikit-image.
 
     Parameters
     ----------
     radar1, radar2 : Radar
         Radar volumes bracketing the target time (``radar1`` earlier). They must
-        contain ``field`` and are assumed to share a scan strategy.
+        contain every requested field (and ``flow_field``) and are assumed to
+        share a scan strategy.
     alpha : float, optional
         Fractional time of the target between ``radar1`` (0.0) and ``radar2``
         (1.0). If None, it is derived from ``target_time`` or defaults to 0.5.
     target_time : datetime, optional
         Absolute target time. Used to compute ``alpha`` from the mean volume
         times when ``alpha`` is not given.
-    field : str, optional
-        Field to interpolate. Defaults to ``"reflectivity"`` if present.
+    field : str or list of str, optional
+        Field or fields to interpolate. A single string interpolates one field
+        (and the returned radar holds just that field); a list interpolates each
+        field in turn using the shared motion field. Defaults to
+        ``"reflectivity"`` if present.
     grid_shape : 3-tuple of int, optional
         (nz, ny, nx) of the intermediate Cartesian grid used for flow estimation.
     grid_limits : 3-tuple of 2-tuple of float, optional
@@ -243,8 +256,17 @@ def advection_interpolate(
     echo_threshold : float, optional
         Field value (dBZ) above which a grid cell is treated as echo when
         extending the motion field into no-echo regions. Default 5.
-    interp_field_name : str, optional
-        Name of the field in the returned radar. Defaults to ``field``.
+    interp_field_name : str or dict, optional
+        Name(s) for the interpolated field(s) in the returned radar. When
+        ``field`` is a single string this may be a string that renames it. When
+        ``field`` is a list this may be a ``{source_field: new_name}`` dict that
+        renames a subset; unlisted fields keep their original names. If None,
+        every field keeps its original name.
+    flow_field : str, optional
+        The single field the motion is estimated from. Defaults to
+        ``"reflectivity"`` if it is among the requested fields (or present in
+        ``radar1``), otherwise the first requested field. It does not need to be
+        one of the interpolated fields.
     gridding_kwargs : dict, optional
         Extra keyword arguments passed to
         :py:func:`pyart.map.grid_from_radars`.
@@ -254,8 +276,8 @@ def advection_interpolate(
     Returns
     -------
     radar_out : Radar
-        A copy of ``radar1`` whose ``interp_field_name`` field holds the
-        reconstructed volume at the target time.
+        A copy of ``radar1`` holding the reconstructed field(s) at the target
+        time (renamed per ``interp_field_name``).
 
     Notes
     -----
@@ -265,6 +287,11 @@ def advection_interpolate(
     largest at long range, where gates are large and echo moves several
     gate-widths between volumes. Purely kinematic morphing cannot represent
     storm growth or decay, so residual error concentrates at cell edges.
+
+    Because the motion field is estimated only from ``flow_field``, non-echo
+    moments (velocity, dual-pol variables) are advected along the reflectivity
+    motion; this is appropriate where the moments move with the echo but is not
+    a substitute for moment-specific tracking.
 
     See Also
     --------
@@ -277,10 +304,40 @@ def advection_interpolate(
             "scikit-image is required for advection_interpolate but is not installed"
         )
 
+    # normalise `field` to a list, remembering whether a single field was asked
+    # for so the rename semantics below stay backward compatible.
     if field is None:
         field = "reflectivity"
+    single_field = isinstance(field, str)
+    fields = [field] if single_field else list(field)
+    if not fields:
+        raise ValueError("`field` must name at least one field")
+
+    # every requested field must be present in both volumes
+    for fname in fields:
+        for r, label in ((radar1, "radar1"), (radar2, "radar2")):
+            if fname not in r.fields:
+                raise KeyError(f"field {fname!r} not found in {label}")
+
+    # the motion is estimated from ONE field only (the scene's echo motion)
+    if flow_field is None:
+        flow_field = "reflectivity" if "reflectivity" in fields else fields[0]
+    if flow_field not in radar1.fields or flow_field not in radar2.fields:
+        raise KeyError(f"flow_field {flow_field!r} not found in both radars")
+
+    # resolve output names into a {source_field: output_name} mapping
     if interp_field_name is None:
-        interp_field_name = field
+        name_map = {f: f for f in fields}
+    elif single_field and isinstance(interp_field_name, str):
+        name_map = {fields[0]: interp_field_name}
+    elif isinstance(interp_field_name, dict):
+        name_map = {f: interp_field_name.get(f, f) for f in fields}
+    else:
+        raise TypeError(
+            "interp_field_name must be a str (single field) or a dict "
+            "{source_field: new_name} (list of fields)"
+        )
+
     if gridding_kwargs is None:
         gridding_kwargs = {}
 
@@ -295,11 +352,12 @@ def advection_interpolate(
             alpha = 0.5
     alpha = float(alpha)
 
-    # grid both volumes and estimate the dense motion field
+    # grid both volumes on the flow field only and estimate the dense motion
+    # field once (this is the expensive step, shared across all output fields).
     grid_kw = dict(
         grid_shape=grid_shape,
         grid_limits=grid_limits,
-        fields=[field],
+        fields=[flow_field],
         weighting_function="Barnes2",
         roi_func="dist_beam",
         min_radius=1000.0,
@@ -308,22 +366,24 @@ def advection_interpolate(
     grid1 = grid_from_radars(radar1, **grid_kw)
     grid2 = grid_from_radars(radar2, **grid_kw)
 
-    disp_y, disp_x = grid_optical_flow(grid1, grid2, field, **flow_kwargs)
+    disp_y, disp_x = grid_optical_flow(grid1, grid2, flow_field, **flow_kwargs)
 
     z = grid1.z["data"]
     y = grid1.y["data"]
     x = grid1.x["data"]
-    d1 = np.ma.filled(grid1.fields[field]["data"], np.nan)
-    d2 = np.ma.filled(grid2.fields[field]["data"], np.nan)
+    d1 = np.ma.filled(grid1.fields[flow_field]["data"], np.nan)
+    d2 = np.ma.filled(grid2.fields[flow_field]["data"], np.nan)
     echo = (d1 > echo_threshold) | (d2 > echo_threshold)
     fy, fx = _displacement_interpolators(disp_y, disp_x, echo, z, y, x)
 
     # advect each gate of radar1's geometry to the target time and blend.
     # displacement disp is the physical grid1 -> grid2 echo motion, so a feature
     # seen at gate g at the target time was at g - alpha * disp in radar1 and at
-    # g + (1 - alpha) * disp in radar2.
+    # g + (1 - alpha) * disp in radar2. The advected query coordinates
+    # (az1/r1, az2/r2) depend only on geometry and the motion field, so they are
+    # computed once per sweep and reused to sample every requested field.
     zlo, zhi = z[0], z[-1]
-    out = np.full((radar1.nrays, radar1.ngates), np.nan)
+    outs = {f: np.full((radar1.nrays, radar1.ngates), np.nan) for f in fields}
     gx_all = radar1.gate_x["data"]
     gy_all = radar1.gate_y["data"]
     gz_all = radar1.gate_z["data"]
@@ -350,19 +410,24 @@ def advection_interpolate(
         az2 = np.rad2deg(np.arctan2(x2, y2)) % 360.0
         r2 = np.hypot(x2, y2) / cos_e
 
-        v1 = _sample_native(az1, r1, _sweep_sampler(radar1, sweep, field))
-        v2 = _sample_native(az2, r2, _sweep_sampler(radar2, sweep, field))
+        # sample and blend each requested field using the shared query geometry
+        for fname in fields:
+            v1 = _sample_native(az1, r1, _sweep_sampler(radar1, sweep, fname))
+            v2 = _sample_native(az2, r2, _sweep_sampler(radar2, sweep, fname))
 
-        both = np.isfinite(v1) & np.isfinite(v2)
-        blended = np.where(
-            both,
-            (1.0 - alpha) * v1 + alpha * v2,
-            np.where(np.isfinite(v1), v1, v2),
-        )
-        out[start : end + 1] = blended
+            both = np.isfinite(v1) & np.isfinite(v2)
+            blended = np.where(
+                both,
+                (1.0 - alpha) * v1 + alpha * v2,
+                np.where(np.isfinite(v1), v1, v2),
+            )
+            outs[fname][start : end + 1] = blended
 
     radar_out = copy.deepcopy(radar1)
-    field_dict = copy.deepcopy(radar1.fields[field])
-    field_dict["data"] = np.ma.masked_invalid(out)
-    radar_out.fields = {interp_field_name: field_dict}
+    new_fields = {}
+    for fname in fields:
+        field_dict = copy.deepcopy(radar1.fields[fname])
+        field_dict["data"] = np.ma.masked_invalid(outs[fname])
+        new_fields[name_map[fname]] = field_dict
+    radar_out.fields = new_fields
     return radar_out


### PR DESCRIPTION
## Summary
`advection_interpolate` previously reconstructed a single field per call. This
extends it to interpolate **multiple fields in one call**, reusing a single
motion field. The `field` argument now accepts a string (unchanged behaviour)
or a list of strings.

## Motivation
The motion of the scene is a property of the echo, not of any one moment, and
the optical-flow estimation is the expensive step. Interpolating N fields by
calling the function N times re-grids and re-estimates the flow N times, which
is wasteful and can yield slightly inconsistent motion between moments. It is
both faster and more correct to estimate the motion once and advect every
moment along it.

## What changed
- `field` accepts a `str` or `list[str]`. A single string is fully backward
  compatible: the returned radar holds just that field.
- New `flow_field` parameter names the single field the motion is estimated
  from (default: `"reflectivity"` if requested/present, else the first field).
  It need not be one of the interpolated fields.
- The gridding, optical flow, and per-sweep advection geometry (advected
  azimuth/range for both bracketing volumes) are computed **once** and reused
  across all requested fields; only the per-field native sampling and blend run
  per field.
- `interp_field_name` now also accepts a `{source_field: new_name}` dict to
  rename selected outputs when interpolating a list (a plain string still
  renames the single-field case).

## Backward compatibility
A single-string `field` call is unchanged. Verified on ARM BNF CSAPR2 data: the
reconstructed reflectivity from a multi-field call is **bit-for-bit identical**
to the previous single-field result.

## Testing
On the QLCS case (2025-04-06 05:30/05:40 UTC), interpolating
`[attenuation_corrected_reflectivity_h, mean_doppler_velocity,
differential_phase]` in one call:
- each moment is reconstructed in its correct physical range (velocity bipolar
  about zero, differential phase within ±180°);
- the three-field call costs essentially the same as one field (~7.8 s vs
  ~7.5 s), confirming the flow is estimated only once;
- explicit `flow_field` and dict-based renaming both behave as documented.

## Notes
Because the motion field comes only from `flow_field`, non-echo moments are
advected along the reflectivity motion. This is appropriate where the moments
move with the echo but is not a substitute for moment-specific tracking.